### PR TITLE
feat: dynamically determine workspace count

### DIFF
--- a/config.h
+++ b/config.h
@@ -7,9 +7,20 @@
  * User configuration options.  Obviously you need to recompile for these to take effect.
  */
 
+// The number of rows you want the workspaces circles to be spread across.
+// If NUM_ROWS does not divide your number of workspaces evenly, the
+// final row will have fewer circles.
+#define NUM_ROWS 3
+
+// If your WM/DE does not expose or otherwise correctly report the
+// '_NET_NUMBER_OF_DESKTOPS' atom, you may opt to manually specify the number of
+// workspaces you have.
+#define STATIC_WORKSPACE_COUNT 0
+
 // Set to however many workspaces you have on your desktop (designed to work
 // with 9 or 10, any other amounts will require modification to the display
-// printing code if you want it to look pretty)
+// printing code if you want it to look pretty). Setting this value has no
+// effect if STATIC_WORKSPACE_COUNT is set to 0.
 #define WORKSPACE_COUNT 10
 
 // Colours


### PR DESCRIPTION
Opt-out feature, can be disabled by setting `STATIC_WORKSPACE_COUNT` to a non-0 value in `config.h`.

Requires WM/DE to support the `_NET_NUMBER_OF_DESKTOPS` atom. Currently only tested on bspwm, behaves as expected. Can't say for certain whether this breaks on other WM/DEs, hence the opt-out.